### PR TITLE
ci: prevent non-release commits from publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Verify release policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq empty release-please-config.json
+          for type in build chore ci docs refactor style test; do
+            jq -e \
+              --arg type "$type" \
+              'any(.["changelog-sections"][]; .type == $type and .hidden == true)' \
+              release-please-config.json >/dev/null
+          done
+
       - name: Verify formatting
         shell: bash
         run: |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,19 +8,23 @@
   "changelog-sections": [
     {
       "type": "build",
-      "section": "Build System"
+      "section": "Build System",
+      "hidden": true
     },
     {
       "type": "chore",
-      "section": "Maintenance"
+      "section": "Maintenance",
+      "hidden": true
     },
     {
       "type": "ci",
-      "section": "Continuous Integration"
+      "section": "Continuous Integration",
+      "hidden": true
     },
     {
       "type": "docs",
-      "section": "Documentation"
+      "section": "Documentation",
+      "hidden": true
     },
     {
       "type": "feat",
@@ -36,7 +40,8 @@
     },
     {
       "type": "refactor",
-      "section": "Code Refactoring"
+      "section": "Code Refactoring",
+      "hidden": true
     },
     {
       "type": "revert",
@@ -44,11 +49,13 @@
     },
     {
       "type": "style",
-      "section": "Styles"
+      "section": "Styles",
+      "hidden": true
     },
     {
       "type": "test",
-      "section": "Tests"
+      "section": "Tests",
+      "hidden": true
     }
   ],
   "packages": {


### PR DESCRIPTION
## Summary

- mark `build`, `chore`, `ci`, `docs`, `refactor`, `style`, and `test` commits as hidden from Release Please
- keep `feat`, `fix`, `perf`, `revert`, and breaking changes release-producing
- enforce the non-release classification in the required build workflow

## Validation

- `jq` release-policy assertions
- `actionlint`
- `gofmt` and `go mod tidy` diff checks
- `go vet ./...`
- `go test -race -coverprofile=coverage.out -covermode=atomic ./...`
- 80.3% coverage against the 65.0% gate

After merge, the Release workflow must complete without creating a release PR or running the publish job.